### PR TITLE
Adding versioning to dataclay images

### DIFF
--- a/docker-compose-it2/docker-compose.yml
+++ b/docker-compose-it2/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       - "6472"
 
   logicmodule1:
-    image: "bscdataclay/logicmodule:mf2c"
+    image: mf2c/dataclay-logicmodule:2.6
     ports:
       - "1034:1034"
     env_file:
@@ -92,7 +92,7 @@ services:
       - ./prop/log4j2.xml:/usr/src/dataclay/log4j2.xml:ro
 
   ds1java1:
-    image: "bscdataclay/dsjava:mf2c"
+    image: mf2c/dataclay-dsjava:2.6
     depends_on:
       - logicmodule1
     env_file:


### PR DESCRIPTION
Added support for Event resource, also I have moved the images from dataclay dockerhub to mf2c docker hub in order to have consistent versions of dcproxy and dataclay (2.6 now).