### PR TITLE
updated docker-compose-it2 to add volumes pkidata for cau-client v1.0…

### DIFF
--- a/docker-compose-it2/docker-compose.yml
+++ b/docker-compose-it2/docker-compose.yml
@@ -191,7 +191,10 @@ services:
   #     - 46060
   #
   # cau-client:
-  #   image: mf2c/cau-client:v1.03
+  #   #v1.02 has changes for writing credentials to shared data volume
+  #   image: mf2c/cau-client:v1.02
+  #   volumes:
+  #     - pkidata:/pkidata
   #   depends_on:
   #     - policies
   #   expose:
@@ -297,3 +300,4 @@ volumes:
   landscaper: {}
   ringcontainer: {}
   ringcontainerexample: {}
+  pkidata: {}


### PR DESCRIPTION
updated docker-compose-it2 to add volumes pkidata for cau-client v1.02 to enable traefik to pick up the agent's cert and key (server.key + server.crt)  Cris you need to add pkidata as a RO volume to traefik.