### PR TITLE
Fix connections between intel components

### DIFF
--- a/docker-compose-it2/analytics_engine.conf
+++ b/docker-compose-it2/analytics_engine.conf
@@ -11,7 +11,7 @@ debug = true
 # deployment
 [INFLUXDB]
 INFLUX = True
-INFLUX_IP = influxdb
+INFLUX_IP = mf2c_influxdb_1
 INFLUX_PORT = 8086
 INFLUX_USER = admin
 INFLUX_PASSWD = admin
@@ -29,7 +29,7 @@ telemetry=snap
 # TODO: change parameters accordingly to your Landscaper
 # deployment
 [LANDSCAPE]
-host=web
+host=mf2c_web_1
 port=9001
 
 # The engine supports Snap telemetry framework
@@ -49,7 +49,7 @@ dbname=snap
 # TODO: change parameters accordingly to your CIMI
 # deployment
 [CIMI]
-url=https://cimi/api
+url=https://proxy:443/api
 
 # Enables internal differentiation between actual
 # deployment and testing/debugging phases.

--- a/docker-compose-it2/docker-compose.yml
+++ b/docker-compose-it2/docker-compose.yml
@@ -199,6 +199,8 @@ services:
     image: mf2c/analytics-engine:0.3
     expose:
       - "46020"
+    ports:
+      - "46020:46020"
     depends_on:
       - influxdb
     volumes:
@@ -221,7 +223,7 @@ services:
       - OS_USERNAME=
       - OS_PASSWORD=
       - OS_AUTH_URL=
-    command: ["./start.sh", "http://neo4j:7474"]
+    command: ["./start.sh", "http://mf2c_neo4j_1:7474"]
   
   snaptemp:
     image: mf2c/snaptemp:0.1
@@ -244,6 +246,7 @@ services:
       - INFLUXDB_HTTP_LOG_ENABLED=false
   snap:
     image: intelsdi/snap:xenial
+    hostname: snap
     ports:
       - "8181:8181"
     volumes: ['/proc:/proc_host', '/sys/fs/cgroup:/sys/fs/cgroup', '/var/run/docker.sock:/var/run/docker.sock']

--- a/docker-compose-it2/landscaper.cfg
+++ b/docker-compose-it2/landscaper.cfg
@@ -13,7 +13,7 @@ types_to_filter =
 
 [neo4j]
 use_bolt=False
-url=http://neo4j:7474/db/data
+url=http://mf2c_neo4j_1:7474/db/data
 user=neo4j
 password=password
 


### PR DESCRIPTION
I have been testing analytics, snap, etc, with @svoorakk , and found that the connections between them were wrong. 

I prefer to set then `hostname` in the docker-compose.yml, instead of assuming the name is mf2c_xxx_1 (which happens when running `docker-compose -p mf2c`).  WDYT?
