### PR TITLE
Modifying landscaper.cfg and a listener to default configuration

### DIFF
--- a/docker-compose-it2/landscaper.cfg
+++ b/docker-compose-it2/landscaper.cfg
@@ -1,6 +1,6 @@
 [general]
 collectors=CimiPhysicalCollector,HWLocCollector
-event_listeners=
+event_listeners=FsEventListener
 graph_db=Neo4jGDB
 flush=True
 cimi_url=https://proxy:443/api


### PR DESCRIPTION
Modifying landscaper.cfg and a listener to default configuration so that the container will not exit. NOTE: In practice, the configuration (landscaper.cfg) is needed to be correctly edited based on the host requirements before starting the landscaper & landscaper web containers.

Output of hello-world.sh : 

iolie@IRILD039:~/mf2c/mf2c/docker-compose-it2$ sh ./hello-world.sh 
./hello-world.sh: 3: ./hello-world.sh: [[: not found
-e 
    Use --include-tests to run all scripts in the 'tests' folder    

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   322  100    90  100   232    231    597 --:--:-- --:--:-- --:--:--   832
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   283  100   156  100   127    315    256 --:--:-- --:--:-- --:--:--   570
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   700  100   160  100   540   1684   5684 --:--:-- --:--:-- --:--:--  7368
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1404  100  1250  100   154    406     50  0:00:03  0:00:03 --:--:--   456
User submitted: user/carpio
Service submitted: service/441c11b8-8220-44a5-966d-205b69ae7e17
Agreement submitted: agreement/e4d6f0b1-29a2-4543-9a24-5eb76a98e85b
Service deployment operation is being processed...
