### PR TITLE
Removing snaptemp and replacing with a smaller image (telem_start)

### DIFF
--- a/docker-compose-it2/docker-compose.yml
+++ b/docker-compose-it2/docker-compose.yml
@@ -16,7 +16,7 @@ services:
 
   ######################## CIMI  #######################
   cimi:
-    image: mf2c/cimi-server:2.13
+    image: mf2c/cimi-server:latest
     restart: on-failure
     depends_on:
       - logicmodule1
@@ -225,9 +225,11 @@ services:
       - OS_AUTH_URL=
     command: ["./start.sh", "http://mf2c_neo4j_1:7474"]
   
-  snaptemp:
-    image: mf2c/snaptemp:0.1
+  telem_start:
+    image: mf2c/telem_start:0.1
     command: sh /download.sh
+    environment:
+      - HOSTNAME
     depends_on:
       - snap
   
@@ -235,6 +237,8 @@ services:
     image: influxdb
     expose:
       - "8086"
+    ports:
+      - "8086:8086"
     volumes:
       - influx:/var/lib/influxdb
     environment:
@@ -284,3 +288,4 @@ volumes:
   landscaper: {}
   ringcontainer: {}
   ringcontainerexample: {}
+

--- a/docker-compose-it2/landscaper.cfg
+++ b/docker-compose-it2/landscaper.cfg
@@ -1,6 +1,6 @@
 [general]
 collectors=CimiPhysicalCollector,HWLocCollector
-event_listeners=FsEventListener
+event_listeners=CimiListener,FsEventListener
 graph_db=Neo4jGDB
 flush=True
 cimi_url=https://proxy:443/api


### PR DESCRIPTION
Usage of Snaptemp has been removed and replace with telem_start which is a smaller, alpine based image. The telem_start image also removes hardcoding of hostname in the telemetry task configuration.

Output of hello-world.sh

iolie@IRILD039:~/mf2c/mf2c/docker-compose-it2$ ./hello-world.sh

    Use --include-tests to run all scripts in the 'tests' folder    

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   328  100    96  100   232   2526   6105 --:--:-- --:--:-- --:--:--  8631
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   283  100   156  100   127   4105   3342 --:--:-- --:--:-- --:--:--  7447
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   700  100   160  100   540   4324  14594 --:--:-- --:--:-- --:--:-- 18918
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1409  100  1255  100   154    647     79  0:00:01  0:00:01 --:--:--   727
User submitted: user/carpio
Service submitted: service/4864e9b8-0d1b-475e-a956-9523346e7beb
Agreement submitted: agreement/f3788049-c8d1-4430-ae1a-3c7badbb15eb
Service deployment operation is being processed...
