### PR TITLE
Changes to add endpoint for fetching landscaper log to landscaper web api

### DIFF
--- a/docker-compose-it2/docker-compose.yml
+++ b/docker-compose-it2/docker-compose.yml
@@ -180,6 +180,7 @@ services:
   
   resource-categorization:
      image: mf2c/resource-categorization:latest-V2.0.9
+     hostname: IRILD039
      restart: on-failure
      depends_on:
        - policies
@@ -204,10 +205,11 @@ services:
       - "traefik.frontend.rule=PathPrefixStrip:/analytics-engine"
   
   landscaper:
-    image: mf2c/landscaper:0.5
+    image: mf2c/landscaper:0.6
     volumes:
     - landscaper:/landscaper/data
     - ./landscaper.cfg:/landscaper/landscaper.cfg
+    - ~/ls_log:/landscaper/logs
     depends_on: ["cimi", "neo4j", "proxy"]
     environment:
       - OS_TENANT_NAME=
@@ -263,11 +265,12 @@ services:
     - NEO4J_AUTH=neo4j/password # neo4j requires change from default password, should reflect landscape.cfg
   
   web:
-    image: mf2c/landscaper:0.5
+    image: mf2c/landscaper:0.6
     environment:
     - PYTHONPATH=/landscaper
     volumes:
       - ./landscaper.cfg:/landscaper/landscaper.cfg
+      - ~/ls_log:/collector_log
     ports:
       - "9001:9001"
     depends_on:


### PR DESCRIPTION
New version of mf2c/landscaper image, added new volume mappings to landscaper & web services.

Output of hello-world.sh

iolie@IRILD039:~/mf2c/mf2c/docker-compose-it2$ ./hello-world.sh 

    Use --include-tests to run all scripts in the 'tests' folder    

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   684  100   166  100   518   2128   6641 --:--:-- --:--:-- --:--:--  8769
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   359  100   156  100   203    368    479 --:--:-- --:--:-- --:--:--   848
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1325  100  1257  100    68   1378     74 --:--:-- --:--:-- --:--:--  1451
SLA template: sla-template/2a562c9f-3080-421b-833e-be22a9406b78
Service: service/8f36f526-6534-454a-9921-c9224cdc60e3
Service instance: Service deployment operation is being processed...
