### PR TITLE
Don't pollute the user's home folder

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -235,7 +235,7 @@ services:
     volumes:
     - landscaper:/landscaper/data
     - ./landscaper.cfg:/landscaper/landscaper.cfg
-    - ~/ls_log:/landscaper/logs
+    - ./ls_log:/landscaper/logs
     - /var/run/docker.sock:/var/run/docker.sock
     depends_on: ["cimi", "neo4j", "proxy"]
     environment:
@@ -298,7 +298,7 @@ services:
     - PYTHONPATH=/landscaper
     volumes:
       - ./landscaper.cfg:/landscaper/landscaper.cfg
-      - ~/ls_log:/collector_log
+      - ./ls_log:/collector_log
     ports:
       - "9001:9001"
     depends_on:


### PR DESCRIPTION
Make landscaper logs be written to the same folder as docker-compose.

I'd question why this is even necessary, as docker already has a logging mechanism.