### PR TITLE
Added updated vpn server image to (fog) compose file

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -307,6 +307,21 @@ services:
     command: ["/usr/local/bin/gunicorn", "-b", "0.0.0.0:9001", "-w", "2", "--chdir", "/landscaper/landscaper/web", "application:APP"]
 ######################################################
 
+  vpnserver:
+    image: mf2c/vpnserver:latest
+    cap_add:
+    - NET_ADMIN
+    container_name: vpnserver
+    environment:
+    - "TRUSTCA=https://213.205.14.13:54443/certauths/rest/it2trustedca"
+    ports:
+    - "1194:1194/udp"
+#    restart: always
+#    networks:
+#    - vpnbridge
+    volumes:
+    - vpnconfig:/etc/openvpn
+
 volumes:
   mydata: {}
   influx: {}
@@ -316,3 +331,4 @@ volumes:
   ringcontainer: {}
   ringcontainerexample: {}
   pkidata: {}
+  vpnconfig: {}


### PR DESCRIPTION
This is the same VPN server as before but has its key management re-engineered to be fully automated (no manual config required): it now generates fresh diffie helman keys (DH) and calls out to the infrastructure (trust) CA for server cert/keys, so deploys entirely out of the docker-compose file.

Note that the client code is only in mF2C/vpn; it has not yet been integrated into the agent - so deploying a standalone server is harmless.
I have tested deployment locally and it works. There is no open issue for this.