### PR TITLE
New dataClay 2.21

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -47,7 +47,7 @@ services:
 
   #################### Dataclay  #######################
   dcproxy:
-    image: mf2c/dataclay-proxy:2.20
+    image: mf2c/dataclay-proxy:2.21
     depends_on:
       - logicmodule1
       - ds1java1
@@ -55,7 +55,7 @@ services:
       - "6472"
 
   logicmodule1:
-    image: mf2c/dataclay-logicmodule:2.20
+    image: mf2c/dataclay-logicmodule:2.21
     ports:
       - "1034:1034"
     env_file:
@@ -68,7 +68,7 @@ services:
       - ./prop/log4j2.xml:/usr/src/dataclay/log4j2.xml:ro
 
   ds1java1:
-    image: mf2c/dataclay-dsjava:2.20
+    image: mf2c/dataclay-dsjava:2.21
     depends_on:
       - logicmodule1
     env_file:


### PR DESCRIPTION
with Service replicated in leaders + deletes + migration of objects caused by updates of agent leaders, backups and children + aware of update of agent ips + associated to new dataclaypre-relase 2.0.dev9
