### PR TITLE
Update analytics-engine to 0.5.5 to handle error when empty graph return

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -215,7 +215,7 @@ services:
 
   ##### Analytics Engine + Recomender + Landscaper #####
   analytics-engine:
-    image: mf2c/analytics-engine:0.5.0
+    image: mf2c/analytics-engine:0.5.5
     expose:
       - "46020"
     ports:


### PR DESCRIPTION
Update analytics-engine to 0.5.5 to handle the error when an empty graph returned from the landscape. 