### PR TITLE
Bump up sla to 0.8; fix docker-compose file errors

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -140,12 +140,10 @@ services:
 
   #################### SLA Manager #####################
   slalite:
-    image: mf2c/sla-management:0.6.0
+    image: mf2c/sla-management:0.8.0
     restart: on-failure
     expose:
       - "46030"
-    environment:
-      - CIMI_URL=https://proxy:443/api
   ######################################################
 
   ################## Resource Manager ##################
@@ -310,7 +308,6 @@ services:
   vpnclient:
     image: mf2c/vpnclient:1.0.0
     depends_on:
-      - vpnserver
       - cau-client
     environment:
       - VPN_DAEMON=FALSE
@@ -322,7 +319,7 @@ services:
 
   resource-bootstrap:
     image: mf2c/resource-bootstrap:1.0.0
-    restart: no
+    restart: "no"
     environment:
       - CIMI_HOST=traefik
       - CIMI_PORT=80


### PR DESCRIPTION
This PR adds several improvements to SLA schema and functionality; it allows assessment of service availabilities relying on ServiceContainerMetrics written by analytics.

It also fix the errors to launch the docker-compose:
- no within quotes (without them, the YAML spec considers `no` as a boolean value, not a string)
- removes dependency of vpnclient to vpnserver (vpnserver does not exist); this may be not intended, but at least, it starts.

CHANGELOG: 

* Add current example of availability and usage [Román SG]
* Add integration test for new CIMI adapter [Román SG]
* Support availability in SLAs [Román SG]
* Add scope, schedule; and refactor assessment model [Román SG]
* Add Assessment.LastValues to agreement model [Román SG]
* Add generic adapter and most of the tests [Román SG]
* Add Variable to model [Román SG]
* Adapt to changes in ServiceOperationReport [Román SG]
* Add repo tests for ServiceOperationReport [Román SG]
* Add repo support for ServiceContainerMetric [Román SG]

HELLO-WORLD-OUTPUT:

```
$ ./hello-world.sh

    Use --include-tests to run all scripts in the 'tests' folder

 [HelloWorldTest]  Starting...
 [ResourceCategorization]  SUCCESS: device dynamic "device-dynamic/37e564a5-4dab-4088-ba25-0e17eb9ef0c4" was created successfully
 [SLAManager]             SUCCESS: service sla-template/78e38222-a5ee-4881-b59e-51f0a9bca611 created successfully
 [ServiceManager]         SUCCESS: service "service/c534503c-9e7c-40f1-ad25-5e67a6877837" created successfully
 [Analytics]              SUCCESS: ip "<hidden>" returned successfully
 [LifecycleManager]       SUCCESS: service instance launched in "<hidden>" successfully
 [HelloWorldTest]         SUCCESS: ip address from service instance matches with is ok
 [LifecycleManager]       INFO:    Service instance status = created-not-initialized...
 [LifecycleManager]       INFO:    Service instance status = started...
 [SlaManagement]          SUCCESS: Agreement created successfully
```