### PR TITLE
Remove \t character from docker-compose

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -198,7 +198,7 @@ services:
   aclib: 
      image: mf2c/aclib:v1.0
      depends_on:
-	- cau-client
+       - cau-client
      volumes:
        - pkidata:/pkidata
      expose:


### PR DESCRIPTION
when deploying the compose, the following error raised.

ERROR: yaml.scanner.ScannerError: while scanning for the next token
found character '\t' that cannot start any token
  in "./docker-compose.yml", line 201, column 1

This bugfix replaces the \t character by whitespaces