### PR TITLE
Updated cau-client version to 2.1, no idkey param

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -187,7 +187,7 @@ services:
        - 46060
 
   cau-client:
-     image: mf2c/cau-client-it2:v2.0
+     image: mf2c/cau-client-it2:v2.1
      depends_on:
        - policies
      volumes:

--- a/docs/cau_client.md
+++ b/docs/cau_client.md
@@ -68,3 +68,11 @@ Rewritten from IT1 version.  CAU-Client now runs a TCP-server to listen to reque
 
  - The get certificate function now takes in 3 arguments: deviceID, detectedLeaderID, IDkey.
  - The Agent's device ID, signed certificate and private key is written to /pkidata 
+ 
+### 2.1 (28/08/2019)
+
+#### Changed
+ - removed the IDKey parameter for the get cert operation.  Identification block validates this IDKey upstream.
+ - removed commented out redundant code
+ - updated code comments for Javadoc
+


### PR DESCRIPTION
I have aligned cau-client and cau (not in docker-compose) to accept only 2 params (deviceID, detectedLID) for getting an agent certificate.  (Also see https://github.com/mF2C/ResourceManagement/issues/35)  IDKey is not validated by Identification block.   There is only 1 change to the docker-compose file: bumped from cau-client version from 2.0 to 2.1.
