### PR TITLE
Add SLA Mgmt health check in docker-compose

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -148,6 +148,10 @@ services:
     restart: on-failure
     expose:
       - "46030"
+    healthcheck:
+      start_period: 30s
+      retries: 5
+      test: ["CMD", "wget", "--spider", "http://localhost:46030"]
   ######################################################
 
   ################## Resource Manager ##################


### PR DESCRIPTION
```
$ docker-compose -p mf2c ps slalite
     Name                  Command                State              Ports       
---------------------------------------------------------------------------------
mf2c_slalite_1   /opt/slalite/run_slalite.sh   Up (healthy)   46030/tcp, 8090/tcp
```