### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 services:
   ####################### Proxy  ######################
   proxy:
-    image: traefik
+    image: traefik:1.7.14
     restart: unless-stopped
     command: --web --docker --docker.exposedByDefault=false --loglevel=info
     volumes:


### PR DESCRIPTION
Fixed version for traefik as latest 2.0.0 fails with current docker-compose configuration.