### PR TITLE
Exposing port until Discovery adapt to traefik ips

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -64,6 +64,8 @@ services:
        
   logicmodule1:
     image: mf2c/dataclay-logicmodule:2.24
+    ports:
+       - "1034:1034"
     environment:
       - DATACLAY_ADMIN_USER=admin
       - DATACLAY_ADMIN_PASSWORD=admin


### PR DESCRIPTION
actual inter-agent communication might not be ready to go through traefik (agent resource must be properly updated to specify which port to use, currently hardcoded to 1034 and discovery only provides the ip) - to talk