### PR TITLE
amended aclib.sh to remove hardcoded receipient did

### DIFF
--- a/docker-compose/tests/aclib.sh
+++ b/docker-compose/tests/aclib.sh
@@ -225,7 +225,7 @@ fi
 #jwe :
 #create request
 #
-jwe_req="{\"recs\":[\"c6968d75a7df20e2d2f81f87fe69bf0b7dd14f4a22cca5f15ffc645cb4d45944bfdc7a7a970a9e13a331161e304a3094d8e6e362e88bd7df0d7b5473b6d2aa80\"],\"typ\":\"jwe\",\"comp\":\"t\",\"payload\":\"${payload}\",\"sec\":\"pri\"}"
+jwe_req="{\"recs\":[\"${did}\"],\"typ\":\"jwe\",\"comp\":\"t\",\"payload\":\"${payload}\",\"sec\":\"pri\"}"
 #echo "${jwe_req}"
 jwe=$(echo ${jwe_req} | nc ${host_ip} ${port})
 if  [ -z  "${jwe}" ] || [ "${jwe:0:2}" == "err" ] ; then


### PR DESCRIPTION
Replaced the hardcoded recipient's deviceid in the jwe request. 
`[root@stfc-tests tests]# ./aclib.sh
 Tester needs privilege to run Docker commands...
 Tests will be aborted if Agent does not have the necessary mF2C cedentials...
 [ACLibTests]     Starting...
Extracting container id ....
Checking if agent credentials exist....
Setting ACLib IP...
network id: mf2c_default
ALib host ip set to 192.168.176.23
 [ACLibTests]     SUCCESS: Got JWT from ACLib
 [ACLibTests]     SUCCESS:  [CIMI] cloud-entry-point exists
 [ACLibTests]     SUCCESS:  [CIMI] successfully pushed new session template for JWT tokens
 [ACLibTests]     SUCCESS:  [CIMI] successful login with JWT token
 [ACLibTests]     SUCCESS:  [CIMI] deleted JWT session template
 [ACLibTests]     SUCCESS: JWT verified by ACLib
The payload: a top secret message!
 [ACLibTests]     SUCCESS: JWS created by ACLib
verified JWS payload: a top secret message!
 [ACLibTests]     SUCCESS: JWS verfied by ACLib
 [ACLibTests]     SUCCESS: JWE with payload compression created by ACLib
verified JWE payload: a top secret message!
 [ACLibTests]     SUCCESS: JWE with payload compression verfied by ACLib
End of ACLib Tests.....
`