### PR TITLE
Fixed mF2C/vpnclient#4 (occasional json syntax error)

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -290,7 +290,7 @@ services:
        test: curl --fail -s http://localhost:46070/api/v1/resource-management/categorization/start/ || exit 1
 
   vpnclient:
-    image: mf2c/vpnclient:1.1.4
+    image: mf2c/vpnclient:1.1.5
     depends_on:
       - cau-client
     network_mode: "host"


### PR DESCRIPTION
During startup, on some occasions the JSON syntax would be wrong due to missing (not yet gathered) data. This is now fixed (reported by @ALEJANDROJ19 and affects @ssgUPC 