### PR TITLE
policies 2.0.10

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -209,7 +209,7 @@ services:
 
   ############ Resource Manager + Security #############
   policies:
-     image: mf2c/policies:2.0.9
+     image: mf2c/policies:2.0.10
      restart: on-failure
      depends_on:
        - cimi

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -71,7 +71,13 @@ To run policies module along other mF2C components, is necessary to specify the 
 
 ```yaml
 - "MF2C_CLOUD_AGENT=172.0.0.1"
-``` 
+```
+
+##### To specify the amount of retry attempts to register a device
+
+```yaml
+- "REGISTRATION_MAX_RETRY=20"
+```
 
 ### API
 
@@ -276,6 +282,13 @@ curl -X GET "http://localhost/api/v2/resource-management/policies/roleChange/lea
     * If discovery and VPN fail to provide a valid IP of the agent and leader, Policies module will fail to create CIMI agent resource.
 
 ## CHANGELOG
+
+### 2.0.10 (24/10/2019)
+
+#### Changed
+
+    * Identification registration trigger in cloud waits until device is registered.
+    
 
 ### 2.0.9 (23/10/2019)
 


### PR DESCRIPTION
* Identification registration trigger in cloud waits until device is registered.