### PR TITLE
New dataclay 2.28 without controlling if node is reachable

### DIFF
--- a/agent/docker-compose.yml
+++ b/agent/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       
   #################### Dataclay  #######################
   dcproxy:
-    image: mf2c/dataclay-proxy:2.27
+    image: mf2c/dataclay-proxy:2.28
     depends_on:
       - logicmodule1
       - ds1java1
@@ -88,7 +88,7 @@ services:
     logging: *logging_params
        
   logicmodule1:
-    image: mf2c/dataclay-logicmodule:2.27
+    image: mf2c/dataclay-logicmodule:2.28
     ports:
        - "1034:1034"
     environment:
@@ -112,7 +112,7 @@ services:
     logging: *logging_params
 
   ds1java1:
-    image: mf2c/dataclay-dsjava:2.27
+    image: mf2c/dataclay-dsjava:2.28
     depends_on:
       - logicmodule1
     environment:

--- a/agent/docs/dcproxy.md
+++ b/agent/docs/dcproxy.md
@@ -62,6 +62,12 @@ Any update of those fields will move and synchronize objects automatically.
 
 ## CHANGELOG
 
+### 2.28 (21.11.2019)
+
+#### Changed
+
+ - Removed control to check if an IP in Agent resource children IPs field is reachable
+
 ### 2.27 (21.10.2019)
 
 #### Added

--- a/agent/docs/ds1java1.md
+++ b/agent/docs/ds1java1.md
@@ -31,6 +31,12 @@ dataClay API can be found at
 
 ## CHANGELOG
 
+### 2.28 (21.11.2019)
+
+#### Changed
+
+ - Removed control to check if an IP in Agent resource children IPs field is reachable
+
 ### 2.27 (21.10.2019)
 
 #### Added

--- a/agent/docs/logicmodule1.md
+++ b/agent/docs/logicmodule1.md
@@ -44,6 +44,12 @@ SSL_CLIENT_KEY=/ssl/agent.pem #in PEM format
 
 ### Troubleshooting
 
+### 2.28 (21.11.2019)
+
+#### Changed
+
+ - Removed control to check if an IP in Agent resource children IPs field is reachable
+
 ## CHANGELOG
 
 ### 2.27 (21.10.2019)


### PR DESCRIPTION
Please move following docker images from mf2c/trunk before accepting: 

    mf2c/trunk:dataclay-proxy-2.28
    mf2c/trunk:dataclay-logicmodule-2.28
    mf2c/trunk:dataclay-dsjava-2.28

To

    mf2c/dataclay-proxy:2.28
    mf2c/dataclay-logicmodule:2.28
    mf2c/dataclay-dsjava:2.28