### PR TITLE
Fixed the storing point for the microagent's resource info

### DIFF
--- a/microagent/docker-compose.yml
+++ b/microagent/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   installer:
-    image: mf2c/microagent:1.0.4
+    image: mf2c/microagent:1.0.5
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:

--- a/microagent/mf2c-entrypoint.sh
+++ b/microagent/mf2c-entrypoint.sh
@@ -75,7 +75,7 @@ docker run -d --hostname=IRILD039 --privileged \
         -v vpninfo:/vpninfo \
         --name mf2c_micro_resource-categorization \
         --label "PRODUCT=MF2C" \
-        mf2c/resource-categorization:resCatlatest-V2.0.27-arm
+        mf2c/resource-categorization:resCatlatest-V2.0.28-arm
 
 trigger_cat_payload='{
 "deviceID":"'${deviceID}'",


### PR DESCRIPTION
@cjdcordeiro the new ARM docker image for Res-Cat is `resCatlatest-V2.0.28-arm` which is in the `mf2c\trunk` repo and also I have modified the docker-image tag for microagent. Now the new version is - `1.0.5`. So, before you accept the PR, please build the microagent image with the new res-cat arm image and then accept it. I'd also like to inform you that @ALEJANDROJ19 has been already reviewed my code.  