### PR TITLE
New dataClay 2.29 with resource control during updates

### DIFF
--- a/agent/docker-compose.yml
+++ b/agent/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       
   #################### Dataclay  #######################
   dcproxy:
-    image: mf2c/dataclay-proxy:2.28
+    image: mf2c/dataclay-proxy:2.29
     depends_on:
       - logicmodule1
       - ds1java1
@@ -88,7 +88,7 @@ services:
     logging: *logging_params
        
   logicmodule1:
-    image: mf2c/dataclay-logicmodule:2.28
+    image: mf2c/dataclay-logicmodule:2.29
     ports:
        - "1034:1034"
     environment:
@@ -112,7 +112,7 @@ services:
     logging: *logging_params
 
   ds1java1:
-    image: mf2c/dataclay-dsjava:2.28
+    image: mf2c/dataclay-dsjava:2.29
     depends_on:
       - logicmodule1
     environment:

--- a/agent/docs/dcproxy.md
+++ b/agent/docs/dcproxy.md
@@ -62,6 +62,12 @@ Any update of those fields will move and synchronize objects automatically.
 
 ## CHANGELOG
 
+### 2.29 (02.12.2019)
+
+#### Changed
+
+ - Modified exception checking during propagation of updates
+
 ### 2.28 (21.11.2019)
 
 #### Changed

--- a/agent/docs/ds1java1.md
+++ b/agent/docs/ds1java1.md
@@ -31,6 +31,12 @@ dataClay API can be found at
 
 ## CHANGELOG
 
+### 2.29 (02.12.2019)
+
+#### Changed
+
+ - Modified exception checking during propagation of updates
+
 ### 2.28 (21.11.2019)
 
 #### Changed

--- a/agent/docs/logicmodule1.md
+++ b/agent/docs/logicmodule1.md
@@ -44,6 +44,12 @@ SSL_CLIENT_KEY=/ssl/agent.pem #in PEM format
 
 ### Troubleshooting
 
+### 2.29 (02.12.2019)
+
+#### Changed
+
+ - Modified exception checking during propagation of updates
+
 ### 2.28 (21.11.2019)
 
 #### Changed


### PR DESCRIPTION
Please move following docker images from mf2c/trunk before accepting: 

    mf2c/trunk:dataclay-proxy-2.29
    mf2c/trunk:dataclay-logicmodule-2.29
    mf2c/trunk:dataclay-dsjava-2.29

To

    mf2c/dataclay-proxy:2.29
    mf2c/dataclay-logicmodule:2.29
    mf2c/dataclay-dsjava:2.29