### PR TITLE
Upgrade resource-bootstrap to 2.8.6.

### DIFF
--- a/agent/docker-compose.yml
+++ b/agent/docker-compose.yml
@@ -418,7 +418,7 @@ services:
     logging: *logging_params
 
   resource-bootstrap:
-    image: mf2c/resource-bootstrap:2.8.5
+    image: mf2c/resource-bootstrap:2.8.6
     restart: "no"
     environment:
       - CIMI_HOST=proxy

--- a/agent/docs/resource-bootstrap.md
+++ b/agent/docs/resource-bootstrap.md
@@ -13,6 +13,13 @@ No action necessary, the container performs actions without user intervention.
 
 ### 2.8.5 (2019-12-11)
 
+#### Fixed
+
+ - Version 2.8.5 contained temporary files, not ignored by .dockerignore, which contained invalid data and were
+   submitted automatically. This version removes those files by ignoring them at build time.
+
+### 2.8.5 (2019-12-11)
+
 #### Added
 
  - Submit SLA templates instead of agreements when bootstrapping.


### PR DESCRIPTION
Fix temporary files being included in the Docker image.

`.dockerignore` dooesn't work the same way as `.gitignore`. Who'da thunk it.