### PR TITLE
Updated the res-cat with new docker images

### DIFF
--- a/agent/docker-compose.yml
+++ b/agent/docker-compose.yml
@@ -375,7 +375,7 @@ services:
      logging: *logging_params
 
   resource-categorization:
-     image: mf2c/resource-categorization:resCatlatest-V2.0.31
+     image: mf2c/resource-categorization:resCatlatest-V2.0.32
      hostname: IRILD039
      restart: on-failure
      depends_on:

--- a/agent/docs/resource-categorization.md
+++ b/agent/docs/resource-categorization.md
@@ -445,6 +445,11 @@ mf2c-curl-post https://localhost/api/fog-area -d
 
 ## Change LOG 
 
+### `resCatlatest-V2.0.32` (date 12/December/2019) [in complience with CIMI-server - 2.28 +later & DataClay version - 2.29 +later]
+
+#### Changed
+
+ - removed the `unavailable` agent IPs from `childrenIPs` field of `agent` resource
 
 ### `resCatlatest-V2.0.31` (date 03/December/2019) [in complience with CIMI-server - 2.28 +later & DataClay version - 2.29 +later]
 

--- a/microagent/mf2c-entrypoint.sh
+++ b/microagent/mf2c-entrypoint.sh
@@ -92,7 +92,7 @@ docker run -d --hostname=IRILD039 --privileged \
         -v vpninfo:/vpninfo \
         --name mf2c_micro_resource-categorization \
         --label "PRODUCT=MF2C" \
-        mf2c/resource-categorization:resCatlatest-V2.0.29-arm
+        mf2c/resource-categorization:resCatlatest-V2.0.30-arm
 
 trigger_cat_payload='{
 "deviceID":"'${deviceID}'",


### PR DESCRIPTION
Modified the docker-compose file and mf2centrypoint.sh with the newly updated Res-Cat version for removing the `unavailable` agent IPs from the agent resource.