### PR TITLE
Update image versions for Swarm stack support.

### DIFF
--- a/agent/docker-compose.yml
+++ b/agent/docker-compose.yml
@@ -27,7 +27,7 @@ services:
 
   ######################## CIMI  #######################
   cimi:
-    image: mf2c/cimi-server:2.28
+    image: mf2c/cimi-server:2.29-SNAPSHOT
     restart: on-failure
     depends_on:
       - logicmodule1
@@ -189,7 +189,7 @@ services:
 
   ########## Lifecycle Manager + User Manager ##########
   lm-um:
-    image: mf2c/lifecycle-usermngt:1.3.12
+    image: mf2c/trunk:lifecycle-usermngt-1.3.13
     restart: on-failure
     depends_on:
       - cimi
@@ -214,6 +214,7 @@ services:
       - /tmp/mf2c/um:/tmp/mf2c/um
       - /tmp/mf2c/lm:/tmp/mf2c/lm
       - /var/run/docker.sock:/var/run/docker.sock
+      - /usr/bin/docker:/usr/bin/docker
     labels:
       - "traefik.enable=true"
       - "traefik.lm.frontend.rule=PathPrefixStrip:/lm"

--- a/agent/docker-compose.yml
+++ b/agent/docker-compose.yml
@@ -189,7 +189,7 @@ services:
 
   ########## Lifecycle Manager + User Manager ##########
   lm-um:
-    image: mf2c/trunk:lifecycle-usermngt-1.3.13
+    image: mf2c/lifecycle-usermngt:1.3.13
     restart: on-failure
     depends_on:
       - cimi


### PR DESCRIPTION
The lm-um healthcheck is failing because `wget` isn't available in the container. Other functionality is fine, and I have tested my workflow of deploying a swarm stack through mF2C. This may or may not be a deal breaker.