### PR TITLE
Discovery iface env

### DIFF
--- a/agent/docker-compose.yml
+++ b/agent/docker-compose.yml
@@ -261,11 +261,13 @@ services:
      logging: *logging_params
 
   discovery:
-     image: mf2c/discovery:1.6
+     image: mf2c/discovery:1.7
      restart: on-failure
      depends_on:
        - cimi
      network_mode: "host"
+     environment:
+       - "WIFI_DEV_FLAG=${WIFI_DEV_FLAG}"     
      ports:
      - "46040:46040"
      cap_add:

--- a/agent/docs/discovery.md
+++ b/agent/docs/discovery.md
@@ -48,6 +48,12 @@ The discovery component provides the following endpoints:
 
 ## CHANGELOG
 
+### 1.7 (29/11/2019)
+
+#### Added
+
+ - Added retrieval of interface name from env variable for get_ip REST call.
+
 ### 1.6 (28/11/2019)
 
 #### Added

--- a/agent/mf2c.sh
+++ b/agent/mf2c.sh
@@ -161,14 +161,12 @@ if [[ "${IS_CLOUD}" != "True" ]]; then
     then
         WIFI_DEV=$(/sbin/iw dev | awk '$1=="Interface"{print $2}')
         IN_USE=$(ip r | grep default | cut -d " " -f5)
-        #find corresponding phy name
-        if [[ $WIFI_DEV != "" ]]; then
-            PHY=$(cat /sys/class/net/"$WIFI_DEV"/phy80211/name)
-        elif [[ ${IS_CLOUD} != "True" ]]; then
+
+        if [[ $WIFI_DEV == "" && ${IS_CLOUD} != "True" ]]; then
             log "IF" "WiFi interface not detected. VPN connection to cloud will be used."
         fi
 
-        log "IF" "WIFI_DEV=${WIFI_DEV}, IN_USE=${IN_USE}, PHY=${PHY}"
+        log "IF" "WIFI_DEV=${WIFI_DEV}, IN_USE=${IN_USE}"
     else
         echo "ERR: the mF2C system is not compatible with your OS: $machine. Exit..."
         exit 1
@@ -219,7 +217,6 @@ if [[ ! -f .env ]]; then
 isLeader=${IS_LEADER}
 isCloud=${IS_CLOUD}
 MF2C_CLOUD_AGENT=${MF2C_CLOUD_AGENT}
-PHY=${PHY}
 WIFI_DEV_FLAG=${WIFI_DEV}
 usr=${MF2C_USER}
 pwd=${MF2C_PASS}
@@ -274,12 +271,8 @@ do
   fi
 done
 
-progress "90" "Binding wireless interface with discovery container"
-
-#Bind inet to discovery
-
 pid=$(docker inspect -f '{{.State.Pid}}' $container_name)
-# Assign phy wireless interface to the container
+
 if [[ ("$machine" != "Mac") && (${WIFI_DEV} != "") ]]
 then
     #Bring the wireless interface up


### PR DESCRIPTION
- This PR corresponds to discovery version `mf2c/discovery:1.7` , where the GET IP method provided by discovery gets the interface name from the ENV variable (the one that is already set in `mf2c.sh` ) instead of using the first WLAN interface found, which may be different from the one used in `mf2c.sh` **only if the agent machine has more than 1 WLAN interface** . As a result, an `environment`  section has been added to the discovery part in docker-compose.

- Some obsolete commands have been also removed from `mf2c.sh`. 